### PR TITLE
feat: support enum of objects

### DIFF
--- a/jsf/parser.py
+++ b/jsf/parser.py
@@ -224,8 +224,8 @@ class JSF:
             enum_list = schema["enum"]
             assert len(enum_list) > 0, "Enum List is Empty"
             assert all(
-                isinstance(item, (int, float, str, type(None))) for item in enum_list
-            ), "Enum Type is not null, int, float or string"
+                isinstance(item, (int, float, str, dict, type(None))) for item in enum_list
+            ), "Enum Type is not null, int, float, string or dict"
             return JSFEnum.from_dict(
                 {
                     "name": name,

--- a/jsf/schema_types/enum.py
+++ b/jsf/schema_types/enum.py
@@ -12,7 +12,7 @@ _types = {"string": str, "integer": int, "number": float}
 
 
 class JSFEnum(BaseSchema):
-    enum: Optional[List[Union[str, int, float, None]]] = []
+    enum: Optional[List[Union[str, int, float, dict, None]]] = []
     model_config = ConfigDict()
 
     def generate(self, context: Dict[str, Any]) -> Optional[Union[str, int, float]]:

--- a/jsf/tests/data/object-enum.json
+++ b/jsf/tests/data/object-enum.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "enum": [
+        {
+            "code": "1",
+            "value": "CHILD"
+        },
+        {
+            "code": "2",
+            "value": "ADULT"
+        }
+    ]
+}

--- a/jsf/tests/test_default_fake.py
+++ b/jsf/tests/test_default_fake.py
@@ -173,6 +173,18 @@ def test_fake_string_enum(TestData):
     assert all(p.generate() in ["Street", "Avenue", "Boulevard"] for _ in range(100))
 
 
+def test_fake_object_enum(TestData):
+    with open(TestData / "object-enum.json") as file:
+        schema = json.load(file)
+    p = JSF(schema)
+
+    assert isinstance(p.generate(), dict)
+    assert all(
+        p.generate() in [{"code": "1", "value": "CHILD"}, {"code": "2", "value": "ADULT"}]
+        for _ in range(100)
+    )
+
+
 def test_fake_int(TestData):
     with open(TestData / "integer.json") as file:
         schema = json.load(file)


### PR DESCRIPTION
- add support for enum of objects
	> According to the [json-schema specifcation](https://json-schema.org/draft/2020-12/json-schema-validation#name-enum) elements in the enum array might be of any type, so that includes objects.


